### PR TITLE
install only test requirements

### DIFF
--- a/script/cibuild-setup-py
+++ b/script/cibuild-setup-py
@@ -18,6 +18,10 @@ python -m build --sdist --wheel
 echo "## validate wheel install ###################################################"
 pip install dist/*$VERSION*.whl
 echo "## validate tests can run against installed code ###############################"
-pip install -r requirements-dev.txt
+# filename needs to resolved independently as pip requires quoting and doesn't support
+# wildcards when installing extra requirements
+# (see: https://pip.pypa.io/en/stable/user_guide/#installing-from-wheels)
+wheel_file=$(ls dist/*$VERSION*.whl)
+pip install "${wheel_file}[test]"
 pytest --disable-network
 echo "## complete ####################################################################"


### PR DESCRIPTION
don't install complete list of dev requirements for the test execution as this could mask runtime dependencies to dev requirements as discussed in https://github.com/octodns/octodns-template/pull/42