### PR TITLE
v0.0.2 bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## v0.0.2 - 2024-01-30 - release to pypi.org
+## v0.0.2 - 2025-01-30 - release to pypi.org
 
 * bump to v0.0.2 and release to pypi.org
 
-## v0.0.1 - 2024-01-08 - Moving
+## v0.0.1 - 2025-01-08 - Moving
 
 * moving from organization telekom-mms to octodns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## v0.0.2 - 2024-01-30 - release to pypi.org
+
+* bump to v0.0.2 and release to pypi.org
+
+## v0.0.1 - 2024-01-08 - Moving
+
+* moving from organization telekom-mms to octodns

--- a/octodns_autodns/__init__.py
+++ b/octodns_autodns/__init__.py
@@ -14,7 +14,7 @@ from octodns.record import Record
 from octodns.zone import Zone
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.1'
+__version__ = __VERSION__ = '0.0.2'
 
 
 class AutoDNSClientException(ProviderException):


### PR DESCRIPTION
## v0.0.2 - 2024-01-30 - release to pypi.org

* bump to v0.0.2 and release to pypi.org